### PR TITLE
Deny VPN accessing applications extra open ports

### DIFF
--- a/run/root/iptable.sh
+++ b/run/root/iptable.sh
@@ -159,6 +159,8 @@ for incoming_ports_ext_item in "${incoming_ports_ext_array[@]}"; do
 
 		# allows communication from any ip (ext or lan) to containers running in vpn network on specific ports
 		iptables -A INPUT -i "${docker_interface}" -p "${vpn_remote_protocol_item}" --dport "${incoming_ports_ext_item}" -j ACCEPT
+		# deny input to application from vpn
+		iptables -A INPUT -i "${VPN_DEVICE_TYPE}" -p "${vpn_remote_protocol_item}" --dport "${incoming_ports_ext_item}" -j DROP
 
 	done
 
@@ -174,6 +176,8 @@ for lan_network_item in "${lan_network_array[@]}"; do
 
 		# allows communication from lan ip to containers running in vpn network on specific ports
 		iptables -A INPUT -i "${docker_interface}" -s "${lan_network_item}" -d "${docker_network_cidr}" -p tcp --dport "${incoming_ports_lan_item}" -j ACCEPT
+		# deny input to application from vpn
+		iptables -A INPUT -i "${VPN_DEVICE_TYPE}" -p tcp --dport "${incoming_ports_lan_item}" -j DROP
 
 	done
 
@@ -252,6 +256,8 @@ for incoming_ports_ext_item in "${incoming_ports_ext_array[@]}"; do
 
 		# return rule
 		iptables -A OUTPUT -o "${docker_interface}" -p "${vpn_remote_protocol_item}" --sport "${incoming_ports_ext_item}" -j ACCEPT
+		# deny output from application to vpn
+		iptables -A OUTPUT -o "${VPN_DEVICE_TYPE}" -p "${vpn_remote_protocol_item}" --sport "${incoming_ports_ext_item}" -j DROP
 
 	done
 
@@ -267,6 +273,8 @@ for lan_network_item in "${lan_network_array[@]}"; do
 
 		# return rule
 		iptables -A OUTPUT -o "${docker_interface}" -s "${docker_network_cidr}" -d "${lan_network_item}" -p tcp --sport "${incoming_ports_lan_item}" -j ACCEPT
+		# deny output from application to vpn
+		iptables -A OUTPUT -o "${VPN_DEVICE_TYPE}" -p tcp --sport "${incoming_ports_lan_item}" -j DROP
 
 	done
 


### PR DESCRIPTION
This pull request denies `incoming_ports_ext_array` and `incoming_ports_lan_array` from being accessed from the VPN. The idea is those should only be accessible from the LAN/host or the docker network.

Originally I had made a pull request on binhex/arch-delugevpn for this, but you have since moved it to this repo.

The custom VPN I am using seems to forward most/all ports automatically (they're dedicated IP addresses it seems). This is great, however it allows for the web ui and the daemon port (in Deluge) to also be accessible to the VPN network. A user could find my current VPN IP address (from the swarm, or just port scanning random IP addresses) and access either of those services. Granted, they are password protected, but it would be nice to have these ports closed/drop in the IP tables setup.

Not sure if there is a better/more secure way of solving this; all I know is that without this modification, I can see both ports 8112 and 58846 open when I use [a port scanner](https://www.yougetsignal.com/tools/open-ports/) on my VPNs IP address. When I use this modification, they are no longer open.