### PR TITLE
Add support for PIA alternative domain for Wireguard

### DIFF
--- a/run/root/wireguard.sh
+++ b/run/root/wireguard.sh
@@ -31,6 +31,13 @@ function pia_generate_token() {
 
 		if [ "$(echo "${token_json_response}" | jq -r '.status')" != "OK" ]; then
 
+				# get token json response from an alternative domain if the other one fails
+				token_json_response=$(curl --silent --insecure -u "${VPN_USER}:${VPN_PASS}" "https://piaproxy.net/gtoken/generateToken")
+
+		fi
+
+		if [ "$(echo "${token_json_response}" | jq -r '.status')" != "OK" ]; then
+
 			echo "[warn] Unable to successfully download PIA json to generate token for wireguard from URL 'https://www.privateinternetaccess.com/gtoken/generateToken'"
 			echo "[info] ${retry_count} retries left"
 			echo "[info] Retrying in ${retry_wait_secs} secs..."


### PR DESCRIPTION
The main PIA website is inaccessible in some countries, preventing token generation. This PR adds support for the alternative PIA domain that can be used to generate the token when the main domain is inaccessible.

I added the alternative domain wherever I found the main one in the code, so I'm not sure if some of these changes are necessary.