### PR TITLE
Fix arm64 builds

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -44,6 +44,9 @@ refresh.sh
 # pacman packages
 ####
 
+# remove to ensure systemd-resolvconf will not conflict openresolved
+pacman -Rdd --noconfirm systemd-resolvconf || true
+
 # define pacman packages
 pacman_packages="base-devel rust openssl-1.1 kmod openvpn privoxy ipcalc wireguard-tools openresolv libnatpmp ldns"
 


### PR DESCRIPTION
The arm64 build has a package conflict

```
> [6/6] RUN chmod +x /root/*.sh /home/nobody/*.sh /usr/local/bin/*.sh && 	/bin/bash /root/install.sh "int-vpn" "2025120203" "arm64":
2.318 Already up to date.
2.474 resolving dependencies...
2.474 warning: openssl-1.1-1.1.1.w-2 is up to date -- skipping
2.474 warning: kmod-34.2-1 is up to date -- skipping
2.474 warning: ldns-1.8.4-1 is up to date -- skipping
2.478 looking for conflicting packages...
2.478 error: :: openresolv-3.17.0-1 and systemd-resolvconf-258.2-2 are in conflict (resolvconf). Remove systemd-resolvconf? [y/N] 
2.478 :: openresolv-3.17.0-1 and systemd-resolvconf-258.2-2 are in conflict
2.479 unresolvable package conflicts detected
2.479 error: failed to prepare transaction (conflicting dependencies)
```

This PR resolves that conflict by removing systemd-resolvconf before installing openresolv. 

> [!NOTE]  
> `-Rdd` forces removal without dependency checks, but in this minimal image that should work just fine