### PR TITLE
Auto-select iptables backend at startup (nft preferred, legacy fallback)

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -45,7 +45,7 @@ refresh.sh
 ####
 
 # define pacman packages
-pacman_packages="base-devel rust kmod openvpn privoxy ipcalc wireguard-tools libnatpmp ldns"
+pacman_packages="base-devel rust kmod openvpn privoxy ipcalc wireguard-tools libnatpmp ldns iptables"
 
 # install pre-reqs
 pacman -S --needed $pacman_packages --noconfirm

--- a/run/root/iptable-init.sh
+++ b/run/root/iptable-init.sh
@@ -4,9 +4,9 @@ function select_iptables_backend() {
 
 	local backend=""
 
-	# Probe nftables first (the modern default, required on hosts that no
-	# longer auto-load the legacy ip_tables kernel module — e.g. stock
-	# Arch on kernel 6.19+).
+	# Probe nftables first (the modern default, required on hosts where
+	# the legacy ip_tables module is no longer loaded by default - e.g.
+	# current Arch, which ships iptables-nft as the iptables provider).
 	if iptables-nft -n -L &>/dev/null; then
 		backend="nft"
 	elif iptables-legacy -n -L &>/dev/null; then

--- a/run/root/iptable-init.sh
+++ b/run/root/iptable-init.sh
@@ -1,5 +1,37 @@
 #!/bin/bash
 
+function select_iptables_backend() {
+
+	local backend=""
+
+	# Probe nftables first (the modern default, required on hosts that no
+	# longer auto-load the legacy ip_tables kernel module — e.g. stock
+	# Arch on kernel 6.19+).
+	if iptables-nft -n -L &>/dev/null; then
+		backend="nft"
+	elif iptables-legacy -n -L &>/dev/null; then
+		backend="legacy"
+	fi
+
+	if [[ -z "${backend}" ]]; then
+		echo "[crit] Neither iptables backend works on this host." | ts '%Y-%m-%d %H:%M:%.S'
+		echo "[crit] Required kernel modules unavailable: nf_tables (preferred) or ip_tables." | ts '%Y-%m-%d %H:%M:%.S'
+		echo "[crit] On a modern host: try 'sudo modprobe nf_tables' on the docker host." | ts '%Y-%m-%d %H:%M:%.S'
+		echo "[crit] On an older host: try 'sudo modprobe ip_tables' on the docker host." | ts '%Y-%m-%d %H:%M:%.S'
+		exit 1
+	fi
+
+	echo "[info] iptables backend selected: ${backend}" | ts '%Y-%m-%d %H:%M:%.S'
+
+	# Point the default iptables/ip6tables commands at the chosen backend.
+	# A single symlink swap covers every downstream script without touching
+	# any of the existing call sites.
+	for cmd in iptables iptables-save iptables-restore \
+	           ip6tables ip6tables-save ip6tables-restore; do
+		ln -sf "xtables-${backend}-multi" "/usr/bin/${cmd}"
+	done
+}
+
 function accept_vpn_endpoints() {
 
 	local direction="${1}"
@@ -152,6 +184,9 @@ function add_name_servers() {
 }
 
 function main() {
+
+	# choose iptables backend before any rule operations
+	select_iptables_backend
 
 	# drop all for ipv4
 	drop_all_ipv4

--- a/run/root/iptable.sh
+++ b/run/root/iptable.sh
@@ -90,9 +90,15 @@ if [[ "${DEBUG}" == "true" ]]; then
 	echo "[debug] Modules currently loaded for kernel" ; lsmod
 fi
 
-# check we have iptable_mangle, if so setup fwmark
-lsmod | grep iptable_mangle
-iptable_mangle_exit_code="${?}"
+# Probe whether the mangle table is usable. Works regardless of which
+# backend was selected by iptable-init.sh: under the legacy backend it
+# requires the iptable_mangle kernel module; under the nftables backend
+# mangle is provided natively by nf_tables and the probe still succeeds.
+if iptables -t mangle -L &>/dev/null; then
+	iptable_mangle_exit_code=0
+else
+	iptable_mangle_exit_code=1
+fi
 
 if [[ "${iptable_mangle_exit_code}" == 0 ]]; then
 

--- a/run/root/start.sh
+++ b/run/root/start.sh
@@ -164,8 +164,14 @@ else
 
 	fi
 
-	# check if we have iptable_mangle module available
-	check_mangle_available=$(lsmod | grep iptable_mangle)
+	# Functional probe: works on legacy (with iptable_mangle loaded) and on
+	# nft (mangle provided natively by nf_tables). Avoids misleading modprobe
+	# warnings on nft hosts where the legacy module is absent by design.
+	if iptables -t mangle -L &>/dev/null; then
+		check_mangle_available="yes"
+	else
+		check_mangle_available=""
+	fi
 
 	# if mangle module not available then try installing it
 	if [[ -z "${check_mangle_available}" ]]; then


### PR DESCRIPTION
```
modprobe: FATAL: Module ip_tables not found
iptables v1.8.x (legacy): can't initialize iptables table `filter'
```

On modern Arch hosts the legacy `ip_tables` module isn't auto-loaded any more (iptables-nft is the default), so containers using the legacy backend fail at startup. The iptables package already ships both backends as multi-call binaries.

`iptable-init.sh` gains `select_iptables_backend()` which probes `iptables-nft -n -L`, falls back to `iptables-legacy -n -L`, and repoints the six iptables/ip6tables symlinks at the chosen `xtables-*-multi`. `iptable.sh` and `start.sh` also swap their `lsmod | grep iptable_mangle` checks for `iptables -t mangle -L` - under nft there's no separate mangle module, and the old check silently skipped the fwmark setup downstream containers rely on for port forwarding.

Tested on Arch with wireguard: nft selected, WebUI up, port forward issued, fwmark routing works. Legacy fallback and exit-1 branches verified in throwaway containers.

Fixes binhex/arch-delugevpn#444.
